### PR TITLE
simulation loop

### DIFF
--- a/src/pathsim/simulation.py
+++ b/src/pathsim/simulation.py
@@ -757,7 +757,7 @@ class Simulation:
 
     # event system ----------------------------------------------------------------
 
-    def _events(self, t):
+    def _detected_events(self, t):
         """Check for possible (active) events and return them chronologically, 
         sorted by their timestep ratios (closest to the initial point in time).
     
@@ -765,6 +765,11 @@ class Simulation:
         ----------
         t : float
             evaluation time for event function
+
+        Returns
+        -------
+        detected : list[Event]
+            list of detected events within timestep
         """
 
         #iterate all event managers
@@ -1148,7 +1153,7 @@ class Simulation:
         total_evals += self._update(time_dt) 
 
         #handle events chronologically after timestep (+dt)
-        for event, _, ratio in self._events(time_dt):
+        for event, _, ratio in self._detected_events(time_dt):
 
             #fixed timestep -> resolve event directly
             event.resolve(self.time + ratio * dt)  
@@ -1258,7 +1263,7 @@ class Simulation:
         total_evals += self._update(time_dt) 
 
         #handle detected events chronologically after timestep (+dt)
-        for event, close, ratio in self._events(time_dt):
+        for event, close, ratio in self._detected_events(time_dt):
 
             #close enough to event (ratio approx 1) -> resolve it
             if close:

--- a/src/pathsim/simulation.py
+++ b/src/pathsim/simulation.py
@@ -789,7 +789,25 @@ class Simulation:
         self._logger_info("DELINEARIZED")
 
 
-    # event system ----------------------------------------------------------------
+    # event system helpers --------------------------------------------------------
+
+    def _buffer_events(self, t):
+        """Buffer states for event monitoring before the timestep 
+        is taken. 
+
+        This is required to set reference for event monitoring and 
+        backtracking for root finding.
+
+        Parameters
+        ----------
+        t : float 
+            evaluation time for buffering
+        """
+
+        #buffer states for event detection (with timestamp)
+        for event in self._active_events:
+            event.buffer(t)
+
 
     def _detected_events(self, t):
         """Check for possible (active) events and return them chronologically, 
@@ -1016,9 +1034,8 @@ class Simulation:
             block.sample(t)
 
 
-    def _buffer(self, t, dt):
-        """Buffer internal states of blocks and buffer states for event 
-        monitoring before the timestep is taken. 
+    def _buffer_blocks(self, dt):
+        """Buffer internal states of blocks before the timestep is taken. 
 
         This is required for runge-kutta integrators but also for the 
         zero crossing detection of the event handling system.
@@ -1028,8 +1045,6 @@ class Simulation:
 
         Parameters
         ----------
-        t : float 
-            evaluation time for buffering
         dt : float
             timestep
         """
@@ -1037,10 +1052,6 @@ class Simulation:
         #buffer internal states of stateful blocks
         for block in self._active_blocks:
             block.buffer(dt)
-
-        #buffer states for event detection (with timestamp)
-        for event in self._active_events:
-            event.buffer(t)
 
 
     def _step(self, t, dt):
@@ -1138,8 +1149,11 @@ class Simulation:
         #assemble active system components
         self._update_active_components()
 
-        #buffer internal states for solvers and event system
-        self._buffer(self.time, dt)
+        #buffer states for event system
+        self._buffer_events(self.time)
+
+        #buffer internal states for solvers
+        self._buffer_blocks(dt)
 
         #total function evaluations 
         total_evals = 0
@@ -1214,8 +1228,11 @@ class Simulation:
         #assemble active system components
         self._update_active_components()
 
-        #buffer internal states for solvers and event system
-        self._buffer(self.time, dt)
+        #buffer states for event system
+        self._buffer_events(self.time)
+
+        #buffer internal states for solvers
+        self._buffer_blocks(dt)
 
         #total function evaluations and implicit solver iterations
         total_evals, total_solver_its = 0, 0
@@ -1305,8 +1322,11 @@ class Simulation:
         #assemble active system components
         self._update_active_components()
 
-        #buffer internal states for solvers and event system
-        self._buffer(self.time, dt)
+        #buffer states for event system
+        self._buffer_events(self.time)
+
+        #buffer internal states for solvers
+        self._buffer_blocks(dt)
 
         #total function evaluations and implicit solver iterations
         total_evals = 0
@@ -1409,8 +1429,11 @@ class Simulation:
         #assemble active system components
         self._update_active_components()
 
-        #buffer internal states for solvers and event system
-        self._buffer(self.time, dt)
+        #buffer states for event system
+        self._buffer_events(self.time)
+
+        #buffer internal states for solvers
+        self._buffer_blocks(dt)
 
         #total function evaluations and implicit solver iterations
         total_evals, total_solver_its = 0, 0


### PR DESCRIPTION
Refactor of the simulation loop for performance and readability in `pathsim/simulation.py` including:

- more descriptive naming of event handling helper methods and separation of `Simulation._buffer` into `Simulation._buffer_events` and `Simmulation._buffer_blocks`
- separation of fixed/adaptive and implicit/explicit simulation timestepping methods for readability but also to reduce unnecessary branching and therefore improve performance slightly
- added per timestep assembly of lists of active system components instead of checks within the loops, this saves unnecessary branching and loop iterations and improves performance by about 10% if all components are active and even more when more of the system components are inactive
- general cleanup of `Simulation` class with some enhancements to the docstrings