### PR TITLE
Reworked LTI blocks to use Scipy methods

### DIFF
--- a/examples/example_cascade.py
+++ b/examples/example_cascade.py
@@ -10,7 +10,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 
 from pathsim import Simulation, Connection, Subsystem, Interface
-from pathsim.blocks import Source, TransferFunction, Adder, Scope, PID
+from pathsim.blocks import Source, TransferFunctionZPG, Adder, Scope, PID
 from pathsim.blocks.rf import WhiteNoise
 
 from pathsim.solvers import RKCK54
@@ -22,11 +22,8 @@ from pathsim.solvers import RKCK54
 
 in1 = Interface()
 
-p11 = TransferFunction(Poles=[-1], Residues=[10], Const=0)
-p12 = TransferFunction(Poles=[-1], Residues=[1], Const=0)
-p13 = TransferFunction(Poles=[-1], Residues=[1], Const=0)
-
-p2 = TransferFunction(Poles=[-2], Residues=[3], Const=0)
+p1 = TransferFunctionZPG(Zeros=[], Poles=[-1, -1, -1], Gain=10)
+p2 = TransferFunctionZPG(Zeros=[], Poles=[-2], Gain=3)
 
 a1 = Adder()
 a2 = Adder()
@@ -35,15 +32,13 @@ d1 = WhiteNoise(spectral_density=5e-5)
 d2 = WhiteNoise(spectral_density=5e-5)
 
 plant = Subsystem(
-    blocks=[p11, p12, p13, p2, a1, a2, d1, d2, in1],
+    blocks=[p1, p2, a1, a2, d1, d2, in1],
     connections=[
         Connection(in1, p2),
         Connection(p2, a2[0]),
         Connection(d2, a2[1]),
-        Connection(a2, p11, in1[1]),
-        Connection(p11, p12),
-        Connection(p12, p13),
-        Connection(p13, a1[0]),
+        Connection(a2, p1, in1[1]),
+        Connection(p1, a1[0]),
         Connection(d1, a1[1]),
         Connection(a1, in1[0])
         ]

--- a/examples/example_transferfunction.py
+++ b/examples/example_transferfunction.py
@@ -10,7 +10,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 from pathsim import Simulation, Connection
-from pathsim.blocks import Source, Scope, TransferFunction
+from pathsim.blocks import Source, Scope, TransferFunctionPRC
 from pathsim.solvers import RKCK54, GEAR52A
 
 
@@ -29,7 +29,7 @@ residues = [-0.2,      -0.2j,       0.2j,     0.3,     0.3]
 
 #blocks and connections
 Sr = Source(lambda t: int(t>=tau))
-TF = TransferFunction(Poles=poles, Residues=residues, Const=const)
+TF = TransferFunctionPRC(Poles=poles, Residues=residues, Const=const)
 Sc = Scope(labels=["step", "response"])
 
 blocks = [Sr, TF, Sc]

--- a/src/pathsim/blocks/lti.py
+++ b/src/pathsim/blocks/lti.py
@@ -300,7 +300,7 @@ class TransferFunctionZPG(StateSpace):
         gain term of transfer function 
     """
 
-    def __init__(self, Zeros=[], Poles=[], Gain=0.0):
+    def __init__(self, Zeros=[], Poles=[], Gain=1.0):
 
         #parameters of transfer function in zeros-poles-gain form
         self.Zeros, self.Poles, self.Gain = Zeros, Poles, Gain

--- a/src/pathsim/blocks/lti.py
+++ b/src/pathsim/blocks/lti.py
@@ -69,7 +69,7 @@ class StateSpace(Block):
     Parameters
     ----------
     A, B, C, D : array_like
-        state space matrices
+        real valued state space matrices
     initial_value : array_like, None
         initial state / initial condition
 
@@ -244,6 +244,13 @@ class TransferFunctionPRC(StateSpace):
 
 
 class TransferFunction(TransferFunctionPRC): 
+    """Alias for `TransferFunctionPRC`.
+
+    .. warning::
+
+        This class will be deprecated in the future as it is an alias for `TransferFunctionPRC`.
+        Please use `TransferFunctionPRC` for future code.
+    """
     
     def __init__(self, Poles=[], Residues=[], Const=0.0):
         super().__init__(Poles, Residues, Const)

--- a/src/pathsim/blocks/lti.py
+++ b/src/pathsim/blocks/lti.py
@@ -12,6 +12,9 @@
 
 import numpy as np
 
+from scipy.signal import ZerosPolesGain
+from scipy.signal import TransferFunction as _TransferFunction
+
 from ._block import Block
 
 from ..utils.register import Register
@@ -188,10 +191,10 @@ class StateSpace(Block):
         return self.engine.step(f, dt)
 
 
-class TransferFunction(StateSpace):
+class TransferFunctionPRC(StateSpace):
     """This block defines a LTI (MIMO for pole residue) transfer function.
 
-    The transfer function is defined in pole-residue form
+    The transfer function is defined in pole-residue-constant (PRC) form
 
     .. math::
         
@@ -228,12 +231,9 @@ class TransferFunction(StateSpace):
         constant term of transfer function
     """
 
-    def __init__(self, 
-                 Poles=[], 
-                 Residues=[], 
-                 Const=0.0):
+    def __init__(self, Poles=[], Residues=[], Const=0.0):
 
-        #model parameters of transfer function in pole-residue form
+        #parameters of transfer function in pole-residue-const form
         self.Const, self.Poles, self.Residues = Const, Poles, Residues
 
         #Statespace realization of transfer function
@@ -241,3 +241,114 @@ class TransferFunction(StateSpace):
 
         #initialize statespace model
         super().__init__(A, B, C, D)
+
+
+class TransferFunction(TransferFunctionPRC): 
+    
+    def __init__(self, Poles=[], Residues=[], Const=0.0):
+        super().__init__(Poles, Residues, Const)
+
+        import warnings
+        warnings.warn(
+            "'TransferFunction' is an alias for 'TransferFunctionPRC' and will be deprecated in the future!"
+            )
+
+
+class TransferFunctionZPG(StateSpace):
+    """This block defines a LTI (SISO) transfer function.
+
+    The transfer function is defined in zeros-poles-gain (ZPG) form
+
+    .. math::
+        
+        \\mathbf{H}(s) = k \\frac{(s - z_1)(s - z_2)\\cdots(s - z_m)}{(s - p_1)(s - p_2)\\cdots(s - p_n)}
+
+    where `Zeros` are the scalar (possibly complex conjugate) zeros of the 
+    transfer function, and `Poles` are the poles (denominator zeros) of the 
+    transfer function. `Gain` is the scalar factor `k`.
+    
+    Upon initialization, the state space realization of the transfer function is 
+    computed using `scipy.signal.ZerosPolesGain(Zeros, Poles, Gain).to_ss()`.
+
+    The resulting state space model of the form
+
+    .. math::
+        
+        \\begin{eqnarray}
+            \\dot{x} &= \\mathbf{A} x + \\mathbf{B} u \\\\
+                   y &= \\mathbf{C} x + \\mathbf{D} u 
+        \\end{eqnarray}
+
+    is handled the same as the 'StateSpace' block, where `A`, `B`, `C` and `D` 
+    are the state space matrices, `x` is the internal state, `u` the input and 
+    `y` the output vector.
+        
+    Parameters
+    ----------
+    Poles : array_like
+        transfer function poles
+    Zeros : array_like
+        transfer function zeros
+    Gain : float
+        gain term of transfer function 
+    """
+
+    def __init__(self, Zeros=[], Poles=[], Gain=0.0):
+
+        #parameters of transfer function in zeros-poles-gain form
+        self.Zeros, self.Poles, self.Gain = Zeros, Poles, Gain
+
+        #build scipy object -> convert to statespace
+        sp_SS = ZerosPolesGain(Zeros, Poles, Gain).to_ss()
+
+        #initialize statespace model
+        super().__init__(sp_SS.A, sp_SS.B, sp_SS.C, sp_SS.D)
+
+
+class TransferFunctionNumDen(StateSpace):
+    """This block defines a LTI (SISO) transfer function.
+
+    The transfer function is defined in polynomial (numerator-denominator) form
+
+    .. math::
+        
+        \\mathbf{H}(s) = \\frac{b_n + b_{n-1} s + \\dots + b_{0} s^n}{a_m + a_{m-1} s + \\dots + a_{0} s^m}
+
+    where `Num` is the list of numerator polynomial coefficients and `Den` the 
+    list of denominator coefficients.
+    
+    Upon initialization, the state space realization of the transfer function is 
+    computed using `scipy.signal.TransferFunction(Num, Den).to_ss()`.
+
+    The resulting state space model of the form
+
+    .. math::
+        
+        \\begin{eqnarray}
+            \\dot{x} &= \\mathbf{A} x + \\mathbf{B} u \\\\
+                   y &= \\mathbf{C} x + \\mathbf{D} u 
+        \\end{eqnarray}
+
+    is handled the same as the 'StateSpace' block, where `A`, `B`, `C` and `D` 
+    are the state space matrices, `x` is the internal state, `u` the input and 
+    `y` the output vector.
+        
+    Parameters
+    ----------
+    Num : array_like
+        numerator polynomial coefficients
+    Den : array_like
+        denominator polynomial coefficients
+    """
+
+    def __init__(self, Num=[], Den=[]):
+
+        #parameters of transfer function in numerator-denominator
+        self.Num, self.Den = Num, Den
+
+        #build scipy object -> convert to statespace
+        sp_SS = _TransferFunction(Num, Den).to_ss()
+
+        #initialize statespace model
+        super().__init__(sp_SS.A, sp_SS.B, sp_SS.C, sp_SS.D)
+

--- a/tests/pathsim/blocks/test_lti.py
+++ b/tests/pathsim/blocks/test_lti.py
@@ -12,7 +12,11 @@
 import unittest
 import numpy as np
 
-from pathsim.blocks.lti import StateSpace, TransferFunctionPRC
+from pathsim.blocks.lti import (
+    StateSpace, 
+    TransferFunctionPRC, 
+    TansferFunction
+    )
 
 #base solver for testing
 from pathsim.solvers._solver import Solver 

--- a/tests/pathsim/blocks/test_lti.py
+++ b/tests/pathsim/blocks/test_lti.py
@@ -12,7 +12,7 @@
 import unittest
 import numpy as np
 
-from pathsim.blocks.lti import StateSpace, TransferFunction
+from pathsim.blocks.lti import StateSpace, TransferFunctionPRC
 
 #base solver for testing
 from pathsim.solvers._solver import Solver 
@@ -164,9 +164,9 @@ class TestStateSpace(unittest.TestCase):
             self.assertTrue(np.all(s==r))
 
 
-class TestTransferFunction(unittest.TestCase):
+class TestTransferFunctionPRC(unittest.TestCase):
     """
-    Test the implementation of the 'TransferFunction' block class
+    Test the implementation of the 'TransferFunctionPRC' block class
 
     inherits most methods from the 'StateSpace' block, so only 
     testing ot the initialization is required
@@ -176,17 +176,17 @@ class TestTransferFunction(unittest.TestCase):
 
         #test default initialization        
         with self.assertRaises(ValueError):
-            T = TransferFunction()
+            T = TransferFunctionPRC()
 
         #test specific initialization (siso)
-        T = TransferFunction(Poles=2, Residues=0.5, Const=5.5)
+        T = TransferFunctionPRC(Poles=2, Residues=0.5, Const=5.5)
         self.assertEqual(T.A, 2)
         self.assertEqual(T.B, 1)
         self.assertEqual(T.C, 0.5)
         self.assertEqual(T.D, 5.5)
 
         #test specific initialization (mimo)
-        T = TransferFunction(Poles=np.array([1, 2]), 
+        T = TransferFunctionPRC(Poles=np.array([1, 2]), 
                              Residues=2*np.ones((2, 2)), 
                              Const=np.ones(2))
         self.assertTrue(np.all(T.A == np.diag(np.array([1, 2]))))

--- a/tests/pathsim/blocks/test_lti.py
+++ b/tests/pathsim/blocks/test_lti.py
@@ -15,7 +15,8 @@ import numpy as np
 from pathsim.blocks.lti import (
     StateSpace, 
     TransferFunctionPRC, 
-    TansferFunction
+    TransferFunctionZPG,
+    TransferFunctionNumDen
     )
 
 #base solver for testing
@@ -173,7 +174,7 @@ class TestTransferFunctionPRC(unittest.TestCase):
     Test the implementation of the 'TransferFunctionPRC' block class
 
     inherits most methods from the 'StateSpace' block, so only 
-    testing ot the initialization is required
+    testing of the initialization is required
     """
 
     def test_init(self):
@@ -197,6 +198,70 @@ class TestTransferFunctionPRC(unittest.TestCase):
         self.assertTrue(np.all(T.B == np.ones(2)))
         self.assertTrue(np.all(T.C == 2*np.ones(2)))
         self.assertTrue(np.all(T.D == np.ones(2)))
+
+
+class TestTransferFunctionZPG (unittest.TestCase):
+    """
+    Test the implementation of the 'TransferFunctionZPG' block class
+
+    inherits most methods from the 'StateSpace' block, so only 
+    testing of the initialization is required
+    """
+
+    def test_init(self):
+
+        #test initialization
+        T = TransferFunctionZPG(Zeros=[], Poles=[-3], Gain=1)
+        self.assertEqual(T.A, -3)
+        self.assertEqual(T.B, 1)
+        self.assertEqual(T.C, 1)
+        self.assertEqual(T.D, 0)
+
+        #test with scipy
+        from scipy.signal import ZerosPolesGain as ZPG
+
+        ss = ZPG([3, 5, 1], [-1, -1, 4, 7], 20).to_ss()
+        T = TransferFunctionZPG([3, 5, 1], [-1, -1, 4, 7], 20)
+        self.assertTrue(np.allclose(T.A, ss.A))
+        self.assertTrue(np.allclose(T.B, ss.B))
+        self.assertTrue(np.allclose(T.C, ss.C))
+        self.assertTrue(np.allclose(T.D, ss.D))
+
+        ss = ZPG([2, 3], [0, -1, -1000], -0.1).to_ss()
+        T = TransferFunctionZPG([2, 3], [0, -1, -1000], -0.1)
+        self.assertTrue(np.allclose(T.A, ss.A))
+        self.assertTrue(np.allclose(T.B, ss.B))
+        self.assertTrue(np.allclose(T.C, ss.C))
+        self.assertTrue(np.allclose(T.D, ss.D))
+
+
+
+class TestTransferFunctionNumDen (unittest.TestCase):
+    """
+    Test the implementation of the 'TransferFunctionNumDen' block class
+
+    inherits most methods from the 'StateSpace' block, so only 
+    testing of the initialization is required
+    """
+
+    def test_init(self):
+
+        from scipy.signal import TransferFunction as TF
+
+        ss = TF([1], [-1]).to_ss()
+        T = TransferFunctionNumDen([1], [-1])
+        self.assertTrue(np.allclose(T.A, ss.A))
+        self.assertTrue(np.allclose(T.B, ss.B))
+        self.assertTrue(np.allclose(T.C, ss.C))
+        self.assertTrue(np.allclose(T.D, ss.D))
+
+        ss = TF([3, 5, 1], [-1, -1, -4, -7]).to_ss()
+        T = TransferFunctionNumDen([3, 5, 1], [-1, -1, -4, -7])
+        self.assertTrue(np.allclose(T.A, ss.A))
+        self.assertTrue(np.allclose(T.B, ss.B))
+        self.assertTrue(np.allclose(T.C, ss.C))
+        self.assertTrue(np.allclose(T.D, ss.D))
+
 
 
 # RUN TESTS LOCALLY ====================================================================


### PR DESCRIPTION
Added transfer function blocks for different formats such as 
* zero-pole-gain -> `TransferFunctionZPG`
* numerator-denominator -> `TransferFunctionNumDen`
* pole-residue-const -> `TransderFunctionPRC` (renamed from `TransferFunction`)