### PR TITLE
event estimation

### DIFF
--- a/examples/examples_event/example_pulse.py
+++ b/examples/examples_event/example_pulse.py
@@ -45,7 +45,7 @@ E = Schedule(
     t_start=tau1, 
     t_end=tau2, 
     t_period=tau2-tau1, 
-    tolerance=1e-6
+    # tolerance=1e-6
     )
 
 events = [E]

--- a/examples/examples_odes/example_flame.py
+++ b/examples/examples_odes/example_flame.py
@@ -14,7 +14,6 @@ from pathsim.blocks import Scope, Integrator, Adder, Function
 from pathsim.solvers import ESDIRK32, ESDIRK43, GEAR52A
 
 
-
 # FLAME INITIAL VALUE PROBLEM ===========================================================
 
 #flame parameter (very stiff)

--- a/src/pathsim/events/_event.py
+++ b/src/pathsim/events/_event.py
@@ -142,6 +142,25 @@ class Event(Serializable):
             self._history = self.func_evt(t), t
 
 
+    def estimate(self, t):
+        """Estimate the time of the next event, based on history or internal schedule.
+
+        This improves simulation performance by estimating events before the simulation 
+        step such that fewer steps have to be rejected for event location. 
+              
+        Parameters
+        ----------
+        t : float 
+            evaluation time for estimation 
+        
+        Returns
+        -------
+        float | None
+            estimated time of event
+        """
+        return None
+
+
     def detect(self, t):
         """Evaluate the event function and decide if an event has occured. 
         Can also use the history of the event function evaluation from 

--- a/src/pathsim/events/_event.py
+++ b/src/pathsim/events/_event.py
@@ -156,7 +156,7 @@ class Event(Serializable):
         Returns
         -------
         float | None
-            estimated time of event
+            estimated time until next event
         """
         return None
 

--- a/src/pathsim/events/schedule.py
+++ b/src/pathsim/events/schedule.py
@@ -84,6 +84,22 @@ class Schedule(Event):
         return self.t_start + len(self._times) * self.t_period
 
 
+    def estimate(self, t):
+        """Estimate the time of the next scheduled event.
+
+        Parameters
+        ----------
+        t : float 
+            evaluation time for estimation 
+        
+        Returns
+        -------
+        float
+            estimated time of event
+        """
+        return self._next()
+
+
     def buffer(self, t):
         """Buffer the current time to history
         

--- a/src/pathsim/events/schedule.py
+++ b/src/pathsim/events/schedule.py
@@ -85,7 +85,7 @@ class Schedule(Event):
 
 
     def estimate(self, t):
-        """Estimate the time of the next scheduled event.
+        """Estimate the time until the next scheduled event.
 
         Parameters
         ----------
@@ -95,9 +95,9 @@ class Schedule(Event):
         Returns
         -------
         float
-            estimated time of event
+            estimated time until next event
         """
-        return self._next()
+        return self._next() - t
 
 
     def buffer(self, t):


### PR DESCRIPTION
Adding estimation of upcoming events for more efficient timestepping. 

Previously, the event system always had to overshoot to detect events, which resulted in many rejected steps and backtracking. This slowed down simulations with many events dramatically. Especially scheduled events (`Schedule`) can be estimated before the timestep is taken and the stepsize can be adjusted to hit the event time exactly in the next step and therefore reducing the number of rejected steps dramatically. 

This was realized by:
* Adding `Event.estimate(t)` method to estimate the time delta until the next event
* Adding `Simulation._estimate_events(t)` method to do the same for the whole simulation with all events
* Using this estimate to adjust the stepsize of the timestep such that events are hit directly (for adaptive timestepping only) in `Simulation.run`

