### PR TITLE
Algebraic Loop Accelerator

### DIFF
--- a/src/pathsim/blocks/_block.py
+++ b/src/pathsim/blocks/_block.py
@@ -415,7 +415,9 @@ class Block(Serializable):
         Returns
         -------
         error : float
-            max absolute error to previous iteration for convergence control
+            max absolute error to previous iteration for convergence control, only relevant 
+            for the subsystem block to propagate errors from internal accelerated connections 
+            (algebraic loops), default 0.0
         """
 
         #no internal algebraic operator -> early exit
@@ -432,8 +434,11 @@ class Block(Serializable):
         else: 
             y = self.op_alg(u)           
 
+        #update register
+        self.outputs.update_from_array(y)
+
         #error control 
-        return self.outputs.update_from_array_max_err(y)
+        return 0.0
 
 
     def solve(self, t, dt):

--- a/src/pathsim/blocks/adder.py
+++ b/src/pathsim/blocks/adder.py
@@ -134,9 +134,9 @@ class Adder(Block):
         Returns
         -------
         error : float
-            absolute error to previous iteration for 
-            convergence control
+            convergence control, default 0.0
         """
         u = self.inputs.to_array()
         y = self.op_alg(u)
-        return self.outputs.update_from_array_max_err(y)
+        self.outputs.update_from_array(y)
+        return 0.0

--- a/src/pathsim/blocks/amplifier.py
+++ b/src/pathsim/blocks/amplifier.py
@@ -75,8 +75,7 @@ class Amplifier(Block):
         Returns
         -------
         error : float
-            max absolute error to previous iteration 
-            for convergence control
+            convergence control, default 0.0
         """
-        y = self.op_alg(self.inputs[0])
-        return self.outputs.update_from_array_max_err(y)
+        self.outputs[0] = self.op_alg(self.inputs[0])
+        return 0.0

--- a/src/pathsim/blocks/ctrl.py
+++ b/src/pathsim/blocks/ctrl.py
@@ -142,15 +142,10 @@ class PID(Block):
         Returns
         -------
         error : float
-            max absolute error to previous iteration for convergence control
+            convergence control, default 0.0
         """
         x, u = self.engine.get(), self.inputs[0]
         y = self.op_alg(x, u, t)
-        
-        #error control, when alg. passthrough
-        if self.Kp or self.Kd:
-            return self.outputs.update_from_array_max_err(y)
-
         self.outputs.update_from_array(y) 
         return 0.0
 

--- a/src/pathsim/blocks/delay.py
+++ b/src/pathsim/blocks/delay.py
@@ -93,8 +93,7 @@ class Delay(Block):
         Returns
         -------
         error : float
-            deviation to previous iteration for convergence 
-            control (always '0.0' because non-algebraic)
+            convergence control, default 0.0
         """
 
         #retrieve value from buffer

--- a/src/pathsim/blocks/differentiator.py
+++ b/src/pathsim/blocks/differentiator.py
@@ -111,13 +111,13 @@ class Differentiator(Block):
         Returns
         -------
         error : float
-            max absolute error to previous iteration 
-            for convergence control
+            convergence control, default 0.0
         """
         x, u = self.engine.get(), self.inputs[0]
         y = self.op_alg(x, u, t)
-        return self.outputs.update_from_array_max_err(y)
-        
+        self.outputs.update_from_array(y)
+        return 0.0
+
 
     def solve(self, t, dt):
         """advance solution of implicit update equation

--- a/src/pathsim/blocks/function.py
+++ b/src/pathsim/blocks/function.py
@@ -141,10 +141,10 @@ class Function(Block):
         Returns
         -------
         error : float
-            max absolute error to previous iteration 
-            for convergence control
+            convergence control, default 0.0
         """
                 
         #apply operator to get output
         y = self.op_alg(self.inputs.to_array())
-        return self.outputs.update_from_array_max_err(y)
+        self.outputs.update_from_array(y)
+        return 0.0

--- a/src/pathsim/blocks/integrator.py
+++ b/src/pathsim/blocks/integrator.py
@@ -101,8 +101,7 @@ class Integrator(Block):
         Returns
         -------
         error : float
-            deviation to previous iteration for convergence 
-            control (always '0.0' because non-algebraic)
+            convergence control, default 0.0
         """
         self.outputs.update_from_array(self.engine.get())
         return 0.0

--- a/src/pathsim/blocks/multiplier.py
+++ b/src/pathsim/blocks/multiplier.py
@@ -63,8 +63,8 @@ class Multiplier(Block):
         Returns
         -------
         error : float
-            maximum absolute error to previous iteration 
-            for convergence control
+            convergence control, default 0.0
         """
         u = self.inputs.to_array()
-        return self.outputs.update_from_array_max_err(self.op_alg(u))
+        self.outputs.update_from_array(self.op_alg(u))
+        return 0.0

--- a/src/pathsim/blocks/noise.py
+++ b/src/pathsim/blocks/noise.py
@@ -93,8 +93,7 @@ class WhiteNoise(Block):
         Returns
         -------
         error : float
-            absolute error to previous iteration for convergence 
-            control (here '0.0' because source-type block)
+            convergence control, default 0.0
         """
         self.outputs[0] = self.noise
         return 0.0

--- a/src/pathsim/blocks/ode.py
+++ b/src/pathsim/blocks/ode.py
@@ -150,8 +150,7 @@ class ODE(Block):
         Returns
         -------
         error : float
-            absolute error to previous iteration for convergence 
-            control (always '0.0' because non-algebraic)
+            convergence control, default 0.0
         """
         self.outputs.update_from_array(self.engine.get())
         return 0.0

--- a/src/pathsim/blocks/rng.py
+++ b/src/pathsim/blocks/rng.py
@@ -81,8 +81,7 @@ class RNG(Block):
         Returns
         -------
         error : float
-            absolute error to previous iteration for convergence 
-            control (always '0.0' because source-type)
+            convergence control, default 0.0
         """
         self.outputs[0] = self.val
         return 0.0

--- a/src/pathsim/blocks/switch.py
+++ b/src/pathsim/blocks/switch.py
@@ -92,12 +92,11 @@ class Switch(Block):
 
         Returns
         -------
-        err : float
-            absolute deviation for convergence control
+        error : float
+            convergence control, default 0.0
         """
         
         #early exit without error control
-        if self.state is None: 
-            self.outputs[0] = 0.0
-            return 0.0
-        return self.outputs.update_from_array_max_err(self.inputs[self.state])
+        if self.state is None: self.outputs[0] = 0.0
+        else: self.outputs[0] = self.inputs[self.state]
+        return 0.0

--- a/src/pathsim/blocks/wrapper.py
+++ b/src/pathsim/blocks/wrapper.py
@@ -88,12 +88,11 @@ class Wrapper(Block):
         ----------
         t : float
             evaluation time
-
+        
         Returns
         -------
         error : float
-            deviation to previous iteration for convergence control
-            here returns '0.0', because no direct passthrough
+            convergence control, default 0.0
         """
         return 0.0
     

--- a/src/pathsim/utils/portreference.py
+++ b/src/pathsim/utils/portreference.py
@@ -58,7 +58,7 @@ class PortReference:
 
     def to(self, other):
         """Transfer the data between two `PortReference` instances, 
-        in this direction `self` -> `other`.
+        in this direction `self` -> `other`. From outputs to inputs.
 
         Parameters
         ----------
@@ -68,6 +68,52 @@ class PortReference:
         for a, b in zip(other.ports, self.ports):
             other.block.inputs[a] = self.block.outputs[b]
 
+
+    def get_inputs(self):
+        """Return the input values of the block at specified ports
+
+        Returns
+        -------
+        out : list[float, obj]
+            input values of block
+        """
+        return [self.block.inputs[p] for p in self.ports]
+
+
+    def set_inputs(self, vals):
+        """Set the block inputs with values at specified ports
+
+        Parameters
+        ----------
+        vals : list[float, obj]
+            values to set at block input ports
+        """
+        for v, p in zip(vals, self.ports):
+            self.block.inputs[p] = v
+
+
+    def get_outputs(self):
+        """Return the output values of the block at specified ports
+
+        Returns
+        -------
+        out : list[float, obj]
+            output values of block
+        """
+        return [self.block.outputs[p] for p in self.ports]
+
+
+    def set_outputs(self, vals):
+        """Set the block outputs with values at specified ports
+
+        Parameters
+        ----------
+        vals : list[float, obj]
+            values to set at block output ports
+        """
+        for v, p in zip(vals, self.ports):
+            self.block.outputs[p] = v
+        
 
     def to_dict(self):
         """Serialization into dict"""

--- a/src/pathsim/utils/register.py
+++ b/src/pathsim/utils/register.py
@@ -103,45 +103,7 @@ class Register:
             if k not in self._values:
                 insort(self._sorted_keys, k)
             self._values[k] = a
-
-
-    def update_from_array_max_err(self, arr):
-        """Update the register values from an array in place and compute 
-        the maximum absolute deviation, which is used in the main simulation 
-        loop for convergencechecks of the fixed point iterations. 
-    
-        Note
-        ----
-        This method is performance critical, since it gets called **A LOT** 
-        and makes up a siginificant portion of all function calls during the 
-        main simulation loop! Its already profiled and optimized, so be 
-        careful with premature *improvements*.
-
-        Parameters
-        ----------
-        arr : numpy.ndarray, float
-            array or scalar that is used to update internal register values
-        
-        Returns
-        -------
-        err : float
-            maximum absolute deviation from previous register values
-        """
-        if np.isscalar(arr):
-            _err = abs(self._values[0] - arr)
-            self._values[0] = arr
-            return _err
-        
-        _max_err = 0.0
-        for k, a in enumerate(arr):
-            if k in self._values:
-                _max_err = max(_max_err, abs(self._values[k] - a))
-            else:
-                insort(self._sorted_keys, k)  
-            self._values[k] = a
-
-        return _max_err
-
+            
 
     def __setitem__(self, key, val):
         """Set the value of `_values`, wraps its setter method. 


### PR DESCRIPTION
Removing the convergence checks of algebraic loops from the blocks and assigning this task to the connections that close loops. The connections that close algebraic loops will now handle the convergence checks and also implement fixed-point-accelerators for robustness.