### PR TITLE
Restart Pulse source cycle at time t

### DIFF
--- a/src/pathsim/blocks/sources.py
+++ b/src/pathsim/blocks/sources.py
@@ -789,6 +789,24 @@ class PulseSource(Block):
         self._phase = 'low'
         self._phase_start_time = self.tau
 
+    def re_initialize(self, t: float):
+        """Restarts the pulse cycle at time t, adjusting all event timings accordingly."""
+        self._phase_start_time = t
+
+        # event timings relative to start of cycle (tau)
+        new_t_start_rise = t
+        new_t_start_high = new_t_start_rise + self.t_rise
+        t_plateau = self.T * self.duty
+        new_t_start_fall = new_t_start_high + t_plateau
+        new_t_start_low = new_t_start_fall + self.t_fall
+
+        self.events[0].t_start = max(0.0, new_t_start_rise)
+        self.events[1].t_start = max(0.0, new_t_start_high)
+        self.events[2].t_start = max(0.0, new_t_start_fall)
+        self.events[3].t_start = max(0.0, new_t_start_low)
+
+        for e in self.events:
+            e.reset()
 
     def update(self, t):
         """Calculate the pulse output value based on the current phase.


### PR DESCRIPTION
## Summary

This PR adds a new method to `PulseSource` for re-initialising the cycle by resetting the internal events and initial delay of the block.

## Current behaviour:
We have noticed the `PulseSource` block when turned on/off didn't restart the cycle and just carries on on the initial schedule.

Consider the following MWE:

```python
import pathsim
from pathsim import Simulation, Connection
import matplotlib.pyplot as plt


# Create global variables
def fun_off_evt(t):
    return t - 10


def fun_off_act(t):
    source_0.off()


def fun_on_evt(t):
    return t - 18


def fun_on_act(t):
    source_0.on()


# Create blocks

source_0 = pathsim.blocks.sources.PulseSource(T=7.5, tau=1)

scope = pathsim.blocks.scope.Scope(labels=["source", "source (real)"])

source_real_2 = pathsim.blocks.sources.PulseSource(T=7.5, tau=1)
blocks = [source_0, scope, source_real_2]


# Create events

turn_off = pathsim.events.zerocrossing.ZeroCrossingUp(
    func_evt=fun_off_evt, func_act=fun_off_act, tolerance=1e-8
)

turn_on = pathsim.events.zerocrossing.ZeroCrossingUp(
    func_evt=fun_on_evt, func_act=fun_on_act, tolerance=1e-8
)
events = [turn_off, turn_on]

# Create connections

connections = [
    Connection(source_0[0], scope[0]),
    Connection(source_real_2[0], scope[1]),
]

# Create simulation
my_simulation = Simulation(
    blocks,
    connections,
    events=events,
    Solver=pathsim.solvers.SSPRK22,
    dt=0.01,
)

if __name__ == "__main__":
    my_simulation.run(30)

    # Optional: Plotting results
    scopes = [block for block in blocks if isinstance(block, pathsim.blocks.Scope)]
    fig, axs = plt.subplots(
        nrows=len(scopes), sharex=True, figsize=(10, 5 * len(scopes))
    )
    for i, scope in enumerate(scopes):
        plt.sca(axs[i] if len(scopes) > 1 else axs)
        time, data = scope.read()
        # plot the recorded data
        for p, d in enumerate(data):
            lb = scope.labels[p] if p < len(scope.labels) else f"port {p}"
            plt.plot(time, d, label=lb, linestyle="--" if p == 1 else "-")
        plt.legend()
    plt.xlabel("Time")
    plt.show()

```

<img width="854" height="469" alt="image" src="https://github.com/user-attachments/assets/1798c3c8-ae7c-41b9-b9a6-72efd8d32183" />

## New behaviour

```python
def fun_on_act(t):
    source_0.on()
    source_0.re_initialize(t)
```

<img width="838" height="448" alt="image" src="https://github.com/user-attachments/assets/ebeb0e08-c30e-4387-950e-a3d08f9f2a51" />


## Discussion

@milanofthe this is very important to have this functionality (restarting a cycle) for reactor restarts. I'm happy to discuss with you on how to improve things like the name of that method and maybe there is a simpler way of achieving this!

Let me know!
