### PR TITLE
Properties for size and shape

### DIFF
--- a/src/pathsim/blocks/_block.py
+++ b/src/pathsim/blocks/_block.py
@@ -199,6 +199,7 @@ class Block(Serializable):
 
     # methods for access to metadata ----------------------------------------------------
 
+    @property
     def size(self):
         """Get size information from block, such as 
         number of internal states, etc.
@@ -212,7 +213,7 @@ class Block(Serializable):
         nx = len(self.engine) if self.engine else 0
         return 1, nx
 
-
+    @property
     def shape(self):
         """Get the number of input and output ports of the block
 

--- a/src/pathsim/simulation.py
+++ b/src/pathsim/simulation.py
@@ -287,6 +287,7 @@ class Simulation:
 
     # methods for access to metadata ----------------------------------------------
 
+    @property
     def size(self):
         """Get size information of the simulation, such as total number 
         of blocks and dynamic states, with recursive retrieval from subsystems
@@ -294,12 +295,12 @@ class Simulation:
         Returns
         -------
         sizes : tuple[int]
-            size of block (default 1) and number 
-            of internal states (from internal engine)
+            size of simulation (number of blocks) and number 
+            of internal states (from internal engines)
         """
         total_n, total_nx = 0, 0
         for block in self.blocks:
-            n, nx = block.size()
+            n, nx = block.size
             total_n += n
             total_nx += nx
         return total_n, total_nx

--- a/src/pathsim/subsystem.py
+++ b/src/pathsim/subsystem.py
@@ -304,6 +304,7 @@ class Subsystem(Block):
 
     # methods for access to metadata --------------------------------------------------------
 
+    @property
     def size(self):
         """Get size information from subsystem, recursively assembled 
         from internal blocks, including nested subsystems.


### PR DESCRIPTION
Previously `Block`, `Subsystem` and `Simulation` had methods `shape` and `size`. It makes more sense for them to be properties. Now thats the case.